### PR TITLE
chore: cleanup source control for doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+doc/tags
 language-server/build/.cache/**

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ require('amazonq').setup({
 3. Run `:AmazonQ` from any file.
 4. *Optional:* Code completions are provided by the "textDocument/completion" LSP method, which "just works" with most autocompletion plugins.
     - Note: completion is limited to supported filetypes.
-    - See [Code Completions](#code-completions).
+    - See [Inline Code Suggestions](#inline-code-suggestions).
 
 ### Using vim-plug
 


### PR DESCRIPTION
# Description

The `doc/tags` file regenerates in project, so should either be added to source control or ignored.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
